### PR TITLE
Github changed their raw url's domain from to raw.githubusecontent.com.

### DIFF
--- a/src/GitHub/GitHubParserHook.php
+++ b/src/GitHub/GitHubParserHook.php
@@ -25,7 +25,7 @@ class GitHubParserHook implements HookHandler {
 	 * @param FileFetcher $fileFetcher
 	 * @param string $gitHubUrl
 	 */
-	public function __construct( FileFetcher $fileFetcher, $gitHubUrl = 'https://raw.github.com' ) {
+	public function __construct( FileFetcher $fileFetcher, $gitHubUrl = 'https://raw.githubusercontent.com' ) {
 		$this->fileFetcher = $fileFetcher;
 		$this->gitHubUrl = $gitHubUrl;
 	}


### PR DESCRIPTION
This patch changes the URL in the plugin to reflect that.

PS: typo in github commit message is not in code.
